### PR TITLE
Enable DecoratedItem components to reclaculate Row Heights

### DIFF
--- a/lib/SortableItem/index.js
+++ b/lib/SortableItem/index.js
@@ -75,7 +75,8 @@ var SortableItem = function (_React$PureComponent) {
           DecoratedItem = _props.itemComponent,
           isDragging = _props.isDragging,
           connectDragSource = _props.connectDragSource,
-          connectDropTarget = _props.connectDropTarget;
+          connectDropTarget = _props.connectDropTarget,
+          recalculateRowHeights = _props.recalculateRowHeights;
 
       return _react2.default.createElement(DecoratedItem, {
         row: row,
@@ -84,7 +85,8 @@ var SortableItem = function (_React$PureComponent) {
         rowStyle: this.props.style,
         isDragging: isDragging,
         connectDragSource: connectDragSource,
-        connectDropTarget: connectDropTarget
+        connectDropTarget: connectDropTarget,
+        recalculateRowHeights: recalculateRowHeights
       });
     }
   }]);

--- a/lib/SortableItem/propTypes.js
+++ b/lib/SortableItem/propTypes.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.connectDragPreview = exports.connectDragSource = exports.connectDropTarget = exports.isDragging = exports.dndDisabled = exports.dropRow = exports.dragEndRow = exports.moveRow = exports.itemComponent = exports.style = exports.listId = exports.rowId = exports.row = undefined;
+exports.recalculateRowHeights = exports.connectDragPreview = exports.connectDragSource = exports.connectDropTarget = exports.isDragging = exports.dndDisabled = exports.dropRow = exports.dragEndRow = exports.moveRow = exports.itemComponent = exports.style = exports.listId = exports.rowId = exports.row = undefined;
 
 var _react = require('react');
 
@@ -23,3 +23,4 @@ var isDragging = exports.isDragging = _react.PropTypes.bool;
 var connectDropTarget = exports.connectDropTarget = _react.PropTypes.func;
 var connectDragSource = exports.connectDragSource = _react.PropTypes.func;
 var connectDragPreview = exports.connectDragPreview = _react.PropTypes.func;
+var recalculateRowHeights = exports.recalculateRowHeights = _react.PropTypes.func;

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -79,6 +79,7 @@ var SortableList = function (_React$PureComponent) {
     });
     _this.renderRow = _this.renderRow.bind(_this);
     _this.renderList = _this.renderList.bind(_this);
+    _this.recalculateRowHeights = _this.recalculateRowHeights.bind(_this);
     return _this;
   }
 
@@ -93,9 +94,14 @@ var SortableList = function (_React$PureComponent) {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps) {
       if (prevProps.list.rows !== this.props.list.rows && !!this._list) {
-        this.cache.clearAll();
-        this._list.wrappedInstance.recomputeRowHeights();
+        this.recalculateRowHeights();
       }
+    }
+  }, {
+    key: 'recalculateRowHeights',
+    value: function recalculateRowHeights() {
+      this.cache.clearAll();
+      this._list.wrappedInstance.recomputeRowHeights();
     }
   }, {
     key: 'renderRow',
@@ -127,7 +133,8 @@ var SortableList = function (_React$PureComponent) {
           dragBeginRow: this.props.dragBeginRow,
           dragEndRow: this.props.dragEndRow,
           findItemIndex: this.props.findItemIndex,
-          dndDisabled: this.props.dndDisabled
+          dndDisabled: this.props.dndDisabled,
+          recalculateRowHeights: this.recalculateRowHeights
         })
       );
     }

--- a/src/SortableItem/index.js
+++ b/src/SortableItem/index.js
@@ -25,6 +25,7 @@ class SortableItem extends React.PureComponent {
       isDragging,
       connectDragSource,
       connectDropTarget,
+      recalculateRowHeights,
     } = this.props;
     return (
       <DecoratedItem
@@ -35,6 +36,7 @@ class SortableItem extends React.PureComponent {
         isDragging={isDragging}
         connectDragSource={connectDragSource}
         connectDropTarget={connectDropTarget}
+        recalculateRowHeights={recalculateRowHeights}
       />
     );
   }

--- a/src/SortableItem/propTypes.js
+++ b/src/SortableItem/propTypes.js
@@ -15,3 +15,4 @@ export const isDragging = PropTypes.bool;
 export const connectDropTarget = PropTypes.func;
 export const connectDragSource = PropTypes.func;
 export const connectDragPreview = PropTypes.func;
+export const recalculateRowHeights = PropTypes.func;

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -29,6 +29,7 @@ class SortableList extends React.PureComponent {
     });
     this.renderRow = this.renderRow.bind(this);
     this.renderList = this.renderList.bind(this);
+    this.recalculateRowHeights = this.recalculateRowHeights.bind(this);
   }
 
   componentDidMount() {
@@ -39,9 +40,13 @@ class SortableList extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     if (prevProps.list.rows !== this.props.list.rows && !!this._list) {
-      this.cache.clearAll();
-      this._list.wrappedInstance.recomputeRowHeights();
+      this.recalculateRowHeights();
     }
+  }
+
+  recalculateRowHeights() {
+    this.cache.clearAll();
+    this._list.wrappedInstance.recomputeRowHeights();
   }
 
   renderRow({ index, key, style, parent}) {
@@ -67,6 +72,7 @@ class SortableList extends React.PureComponent {
           dragEndRow={this.props.dragEndRow}
           findItemIndex={this.props.findItemIndex}
           dndDisabled={this.props.dndDisabled}
+          recalculateRowHeights={this.recalculateRowHeights}
         />
       </CellMeasurer>
     );


### PR DESCRIPTION
redbooth-frontend reveals task controls on hover.  For tasks with long titles this requires us recalculate the row heights cache in order to maintain dynamic spacing.