### PR TITLE
Fix jumpy behavior when paired with self expanding decorated tasks

### DIFF
--- a/lib/SortableItem/index.js
+++ b/lib/SortableItem/index.js
@@ -70,12 +70,6 @@ var SortableItem = function (_React$PureComponent) {
       });
     }
   }, {
-    key: 'componentDidUpdate',
-    value: function componentDidUpdate(prevProps) {
-      if (window._ && window._.isEqual(prevProps, this.props)) return;
-      this.recalculateRowHeights();
-    }
-  }, {
     key: 'recalculateRowHeights',
     value: function recalculateRowHeights() {
       var _props = this.props,

--- a/lib/SortableItem/index.js
+++ b/lib/SortableItem/index.js
@@ -53,9 +53,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var SortableItem = function (_React$PureComponent) {
   (0, _inherits3.default)(SortableItem, _React$PureComponent);
 
-  function SortableItem() {
+  function SortableItem(props) {
     (0, _classCallCheck3.default)(this, SortableItem);
-    return (0, _possibleConstructorReturn3.default)(this, (SortableItem.__proto__ || (0, _getPrototypeOf2.default)(SortableItem)).apply(this, arguments));
+
+    var _this = (0, _possibleConstructorReturn3.default)(this, (SortableItem.__proto__ || (0, _getPrototypeOf2.default)(SortableItem)).call(this, props));
+
+    _this.recalculateRowHeights = _this.recalculateRowHeights.bind(_this);
+    return _this;
   }
 
   (0, _createClass3.default)(SortableItem, [{
@@ -66,17 +70,25 @@ var SortableItem = function (_React$PureComponent) {
       });
     }
   }, {
+    key: 'recalculateRowHeights',
+    value: function recalculateRowHeights() {
+      var _props = this.props,
+          recalculateRowHeights = _props.recalculateRowHeights,
+          rowIndex = _props.rowIndex;
+
+      recalculateRowHeights(rowIndex);
+    }
+  }, {
     key: 'render',
     value: function render() {
-      var _props = this.props,
-          row = _props.row,
-          rowId = _props.rowId,
-          listId = _props.listId,
-          DecoratedItem = _props.itemComponent,
-          isDragging = _props.isDragging,
-          connectDragSource = _props.connectDragSource,
-          connectDropTarget = _props.connectDropTarget,
-          recalculateRowHeights = _props.recalculateRowHeights;
+      var _props2 = this.props,
+          row = _props2.row,
+          rowId = _props2.rowId,
+          listId = _props2.listId,
+          DecoratedItem = _props2.itemComponent,
+          isDragging = _props2.isDragging,
+          connectDragSource = _props2.connectDragSource,
+          connectDropTarget = _props2.connectDropTarget;
 
       return _react2.default.createElement(DecoratedItem, {
         row: row,
@@ -86,7 +98,7 @@ var SortableItem = function (_React$PureComponent) {
         isDragging: isDragging,
         connectDragSource: connectDragSource,
         connectDropTarget: connectDropTarget,
-        recalculateRowHeights: recalculateRowHeights
+        recalculateRowHeights: this.recalculateRowHeights
       });
     }
   }]);

--- a/lib/SortableItem/index.js
+++ b/lib/SortableItem/index.js
@@ -70,6 +70,12 @@ var SortableItem = function (_React$PureComponent) {
       });
     }
   }, {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate(prevProps) {
+      if (window._ && window._.isEqual(prevProps, this.props)) return;
+      this.recalculateRowHeights();
+    }
+  }, {
     key: 'recalculateRowHeights',
     value: function recalculateRowHeights() {
       var _props = this.props,

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -91,14 +91,6 @@ var SortableList = function (_React$PureComponent) {
       });
     }
   }, {
-    key: 'componentDidUpdate',
-    value: function componentDidUpdate(prevProps) {
-      if (window._ && window._.isEqual(prevProps.list.rows, this.props.list.rows)) return;
-
-      this.cache.clearAll();
-      if (this._list) this._list.wrappedInstance.recomputeRowHeights();
-    }
-  }, {
     key: 'recalculateRowHeights',
     value: function recalculateRowHeights(index) {
       this.cache.clear(index);

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -91,6 +91,27 @@ var SortableList = function (_React$PureComponent) {
       });
     }
   }, {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate(prevProps) {
+      var rowIndex = this.findHighestUpdatedRow(this.props.list.rows, prevProps.list.rows);
+      if (rowIndex !== null) {
+        this.cache.clearAll();
+        if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex + 1);
+      }
+    }
+  }, {
+    key: 'findHighestUpdatedRow',
+    value: function findHighestUpdatedRow(rows, prevRows) {
+      if (!window._) return null;
+      for (var i = 0; i < rows.length; i++) {
+        if (!window._.isEqual(rows[i], prevRows[i])) {
+          return i;
+        }
+      }
+
+      return null;
+    }
+  }, {
     key: 'recalculateRowHeights',
     value: function recalculateRowHeights(index) {
       this.cache.clear(index);

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -93,10 +93,10 @@ var SortableList = function (_React$PureComponent) {
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps) {
-      if (prevProps.list.rows !== this.props.list.rows && !!this._list) {
-        this.cache.clearAll();
-        this._list.wrappedInstance.recomputeRowHeights();
-      }
+      if (window._ && window._.isEqual(prevProps.list.rows, this.props.list.rows)) return;
+
+      this.cache.clearAll();
+      if (this._list) this._list.wrappedInstance.recomputeRowHeights();
     }
   }, {
     key: 'recalculateRowHeights',

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -94,14 +94,15 @@ var SortableList = function (_React$PureComponent) {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps) {
       if (prevProps.list.rows !== this.props.list.rows && !!this._list) {
-        this.recalculateRowHeights();
+        this.cache.clearAll();
+        this._list.wrappedInstance.recomputeRowHeights();
       }
     }
   }, {
     key: 'recalculateRowHeights',
-    value: function recalculateRowHeights() {
-      this.cache.clearAll();
-      this._list.wrappedInstance.recomputeRowHeights();
+    value: function recalculateRowHeights(index) {
+      this.cache.clear(index);
+      if (this._list) this._list.wrappedInstance.recomputeRowHeights(index + 1);
     }
   }, {
     key: 'renderRow',
@@ -134,7 +135,8 @@ var SortableList = function (_React$PureComponent) {
           dragEndRow: this.props.dragEndRow,
           findItemIndex: this.props.findItemIndex,
           dndDisabled: this.props.dndDisabled,
-          recalculateRowHeights: this.recalculateRowHeights
+          recalculateRowHeights: this.recalculateRowHeights,
+          rowIndex: index
         })
       );
     }

--- a/lib/demo/index.js
+++ b/lib/demo/index.js
@@ -31,7 +31,7 @@ window.Perf = _reactAddonsPerf2.default;
 function getLists() {
   var lists = window.localStorage.getItem('lists');
 
-  return JSON.parse(lists) || (0, _generateLists.generateLists)(100, 10);
+  return JSON.parse(lists) || (0, _generateLists.generateLists)(100, 300);
 }
 
 function setLists(lists) {

--- a/src/SortableItem/index.js
+++ b/src/SortableItem/index.js
@@ -21,6 +21,11 @@ class SortableItem extends React.PureComponent {
     });
   }
 
+  componentDidUpdate(prevProps) {
+    if (window._ && window._.isEqual(prevProps, this.props)) return;
+    this.recalculateRowHeights();
+  }
+
   recalculateRowHeights() {
     const { recalculateRowHeights, rowIndex} = this.props;
     recalculateRowHeights(rowIndex);

--- a/src/SortableItem/index.js
+++ b/src/SortableItem/index.js
@@ -21,11 +21,6 @@ class SortableItem extends React.PureComponent {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (window._ && window._.isEqual(prevProps, this.props)) return;
-    this.recalculateRowHeights();
-  }
-
   recalculateRowHeights() {
     const { recalculateRowHeights, rowIndex} = this.props;
     recalculateRowHeights(rowIndex);

--- a/src/SortableItem/index.js
+++ b/src/SortableItem/index.js
@@ -10,10 +10,20 @@ import * as propTypes from './propTypes';
 class SortableItem extends React.PureComponent {
   static propTypes = propTypes;
 
+  constructor(props) {
+    super(props);
+    this.recalculateRowHeights = this.recalculateRowHeights.bind(this);
+  }
+
   componentDidMount() {
     this.props.connectDragPreview(getEmptyImage(), {
       captureDraggingState: true
     });
+  }
+
+  recalculateRowHeights() {
+    const { recalculateRowHeights, rowIndex} = this.props;
+    recalculateRowHeights(rowIndex);
   }
 
   render() {
@@ -25,7 +35,6 @@ class SortableItem extends React.PureComponent {
       isDragging,
       connectDragSource,
       connectDropTarget,
-      recalculateRowHeights,
     } = this.props;
     return (
       <DecoratedItem
@@ -36,7 +45,7 @@ class SortableItem extends React.PureComponent {
         isDragging={isDragging}
         connectDragSource={connectDragSource}
         connectDropTarget={connectDropTarget}
-        recalculateRowHeights={recalculateRowHeights}
+        recalculateRowHeights={this.recalculateRowHeights}
       />
     );
   }

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -38,13 +38,6 @@ class SortableList extends React.PureComponent {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (window._ && window._.isEqual(prevProps.list.rows, this.props.list.rows)) return;
-
-    this.cache.clearAll();
-    if (this._list) this._list.wrappedInstance.recomputeRowHeights();
-  }
-
   recalculateRowHeights(index) {
     this.cache.clear(index);
     if (this._list) this._list.wrappedInstance.recomputeRowHeights(index + 1);

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -38,6 +38,25 @@ class SortableList extends React.PureComponent {
     });
   }
 
+  componentDidUpdate(prevProps) {
+    const rowIndex = this.findHighestUpdatedRow(this.props.list.rows, prevProps.list.rows);
+    if (rowIndex !== null) {
+      this.cache.clearAll();
+      if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex + 1);
+    }
+  }
+
+  findHighestUpdatedRow(rows, prevRows) {
+    if (!window._) return null;
+    for (let i = 0; i < rows.length; i++) {
+      if (!window._.isEqual(rows[i], prevRows[i])) {
+        return i;
+      }
+    }
+
+    return null;
+  }
+
   recalculateRowHeights(index) {
     this.cache.clear(index);
     if (this._list) this._list.wrappedInstance.recomputeRowHeights(index + 1);

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -40,13 +40,14 @@ class SortableList extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     if (prevProps.list.rows !== this.props.list.rows && !!this._list) {
-      this.recalculateRowHeights();
+      this.cache.clearAll();
+      this._list.wrappedInstance.recomputeRowHeights();
     }
   }
 
-  recalculateRowHeights() {
-    this.cache.clearAll();
-    this._list.wrappedInstance.recomputeRowHeights();
+  recalculateRowHeights(index) {
+    this.cache.clear(index);
+    if (this._list) this._list.wrappedInstance.recomputeRowHeights(index + 1);
   }
 
   renderRow({ index, key, style, parent}) {
@@ -73,6 +74,7 @@ class SortableList extends React.PureComponent {
           findItemIndex={this.props.findItemIndex}
           dndDisabled={this.props.dndDisabled}
           recalculateRowHeights={this.recalculateRowHeights}
+          rowIndex={index}
         />
       </CellMeasurer>
     );

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -39,10 +39,10 @@ class SortableList extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.list.rows !== this.props.list.rows && !!this._list) {
-      this.cache.clearAll();
-      this._list.wrappedInstance.recomputeRowHeights();
-    }
+    if (window._ && window._.isEqual(prevProps.list.rows, this.props.list.rows)) return;
+
+    this.cache.clearAll();
+    if (this._list) this._list.wrappedInstance.recomputeRowHeights();
   }
 
   recalculateRowHeights(index) {

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -13,7 +13,7 @@ window.Perf = Perf;
 function getLists() {
   const lists = window.localStorage.getItem('lists');
 
-  return JSON.parse(lists) || generateLists(100, 10);
+  return JSON.parse(lists) || generateLists(100, 300);
 }
 
 function setLists(lists) {


### PR DESCRIPTION
Since the frontend's DecoratedTasks components will sometimes expand themselves on hover we need to expose some way of letting them inform the CellMeasurer Cache and the List component what changes have occurred. Otherwise the expanded tasks will bleed into the task beneath it.

We want to do a deep equals check on the `list.rows` content before updating the cache/list since the frontend almost always passes in a new `lists` prop whenever any interaction takes place on the board. (Perhaps due to backbone-redux not using [immutability-helpers](https://reactjs.org/docs/update.html)? RVK uses `react-addons-update` to similar effect so I doubt the issue is internal) Otherwise all the task lists will clear their caches and resize themselves when any task is moved. It would be nice to fix this in the future however since this is a deep equals check on a user-determined array of task objects.

When doing this deep equals check we want to keep track of the index of the changed rows and not recompute row heights for rows higher than the ones that were changed. Else the list will resize and  jump unexpectedly ([similar to this bug](https://github.com/bvaughn/react-virtualized/issues/842))