### PR TITLE
ENG-10276 -- Add custom overscanIndicesGetter fn to render entire list for printing

### DIFF
--- a/lib/Kanban/index.js
+++ b/lib/Kanban/index.js
@@ -116,6 +116,8 @@ var Kanban = function (_React$PureComponent) {
     _this.drawFrame = _this.drawFrame.bind(_this);
     _this.findItemIndex = _this.findItemIndex.bind(_this);
 
+    _this.overscanIndicesGetter = _this.overscanIndicesGetter.bind(_this);
+
     _this.refsByIndex = {};
     return _this;
   }
@@ -283,22 +285,37 @@ var Kanban = function (_React$PureComponent) {
     value: function findItemIndex(itemId) {
       return (0, _updateLists.findItemIndex)(this.state.lists, itemId);
     }
+
+    /**
+     * Allows us to render the entire virtualized component for printing.
+     */
+
+  }, {
+    key: 'overscanIndicesGetter',
+    value: function overscanIndicesGetter(_ref7) {
+      var cellCount = _ref7.cellCount;
+
+      return {
+        overscanStartIndex: 0,
+        overscanStopIndex: cellCount - 1
+      };
+    }
   }, {
     key: 'renderList',
-    value: function renderList(_ref7) {
+    value: function renderList(_ref8) {
       var _this4 = this;
 
-      var columnIndex = _ref7.columnIndex,
-          rowIndex = _ref7.rowIndex,
-          key = _ref7.key,
-          style = _ref7.style,
-          parent = _ref7.parent;
+      var columnIndex = _ref8.columnIndex,
+          rowIndex = _ref8.rowIndex,
+          key = _ref8.key,
+          style = _ref8.style,
+          parent = _ref8.parent;
 
       var list = this.state.lists[columnIndex];
 
       return _react2.default.createElement(_SortableList2.default, {
-        ref: function ref(_ref8) {
-          _this4.refsByIndex[columnIndex] = _ref8;
+        ref: function ref(_ref9) {
+          _this4.refsByIndex[columnIndex] = _ref9;
         },
         key: list.id,
         listId: list.id,
@@ -335,7 +352,14 @@ var Kanban = function (_React$PureComponent) {
           itemPreviewComponent = _props.itemPreviewComponent,
           listPreviewComponent = _props.listPreviewComponent,
           overscanListCount = _props.overscanListCount,
-          initialColumnIndex = _props.initialColumnIndex;
+          initialColumnIndex = _props.initialColumnIndex,
+          isPrinting = _props.isPrinting;
+      // Conditionally override the default 'overscanIndicesGetter' function in
+      // react-virtual-grid, which normally tells us to render only enough items
+      // to fill the viewport. If we're not printing the component, then we pass
+      // in 'undefined' so react-virtual-grid uses its defaultOverscanIndicesGetter.
+
+      var overscanIndicesGetter = isPrinting ? this.overscanIndicesGetter : undefined;
 
       return _react2.default.createElement(
         'div',
@@ -359,7 +383,8 @@ var Kanban = function (_React$PureComponent) {
           horizontalStrength: horizontalStrength,
           scrollToColumn: initialColumnIndex,
           verticalStrength: function verticalStrength() {},
-          speed: HORIZONTAL_SCROLL_SPEED
+          speed: HORIZONTAL_SCROLL_SPEED,
+          overscanIndicesGetter: overscanIndicesGetter
         }),
         _react2.default.createElement(_DragLayer2.default, {
           lists: lists,
@@ -388,7 +413,8 @@ Kanban.defaultProps = {
   onDragEndRow: function onDragEndRow() {},
   overscanListCount: 2,
   overscanRowCount: 2,
-  dndDisabled: false
+  dndDisabled: false,
+  isPrinting: false
 };
 Kanban.childContextTypes = {
   dragDropManager: _react2.default.PropTypes.object

--- a/lib/Kanban/propTypes.js
+++ b/lib/Kanban/propTypes.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.itemComponentProps = exports.listComponentProps = exports.dndDisabled = exports.initialRowIndex = exports.initialColumnIndex = exports.overscanRowCount = exports.overscanListCount = exports.onDragEndRow = exports.onDropList = exports.onDropRow = exports.onMoveList = exports.onMoveRow = exports.listPreviewComponent = exports.itemPreviewComponent = exports.itemComponent = exports.listComponent = exports.height = exports.listWidth = exports.width = exports.lists = undefined;
+exports.isPrinting = exports.itemComponentProps = exports.listComponentProps = exports.dndDisabled = exports.initialRowIndex = exports.initialColumnIndex = exports.overscanRowCount = exports.overscanListCount = exports.onDragEndRow = exports.onDropList = exports.onDropRow = exports.onMoveList = exports.onMoveRow = exports.listPreviewComponent = exports.itemPreviewComponent = exports.itemComponent = exports.listComponent = exports.height = exports.listWidth = exports.width = exports.lists = undefined;
 
 var _react = require('react');
 
@@ -27,3 +27,4 @@ var initialRowIndex = exports.initialRowIndex = _react.PropTypes.number;
 var dndDisabled = exports.dndDisabled = _react.PropTypes.bool;
 var listComponentProps = exports.listComponentProps = _react.PropTypes.object;
 var itemComponentProps = exports.itemComponentProps = _react.PropTypes.object;
+var isPrinting = exports.isPrinting = _react.PropTypes.bool;

--- a/lib/demo/App.js
+++ b/lib/demo/App.js
@@ -4,6 +4,10 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _promise = require('babel-runtime/core-js/promise');
+
+var _promise2 = _interopRequireDefault(_promise);
+
 var _extends2 = require('babel-runtime/helpers/extends');
 
 var _extends3 = _interopRequireDefault(_extends2);
@@ -53,7 +57,8 @@ var App = function (_Component) {
     var _this = (0, _possibleConstructorReturn3.default)(this, (App.__proto__ || (0, _getPrototypeOf2.default)(App)).call(this, props));
 
     _this.state = {
-      lists: props.getLists()
+      lists: props.getLists(),
+      isPrinting: false
     };
 
     setInterval(function () {
@@ -72,17 +77,47 @@ var App = function (_Component) {
         }
       });
     }, 30000);
+
+    _this.print = _this.print.bind(_this);
     return _this;
   }
 
+  /**
+   * This is how we tell the React VirtualKanban component that it needs to render
+   * its entire contents before printing.
+   */
+
+
   (0, _createClass3.default)(App, [{
+    key: 'print',
+    value: function print() {
+      var _this2 = this;
+
+      new _promise2.default(function (resolve) {
+        _this2.setState({ isPrinting: true }, function () {
+          return void 0;
+        });
+        // or use the redux store and fire an action here
+        resolve();
+      }).then(function () {
+        return window.alert('There is no print specific styling applied to ' + 'this, but check dev tools and you\'ll see all lists rendered to the DOM. ' + 'Check now, while this alert is still up, before the preview opens, so you believe me');
+      }).then(function () {
+        return window.print();
+      });
+    }
+  }, {
     key: 'render',
     value: function render() {
-      var _this2 = this;
+      var _this3 = this;
 
       return _react2.default.createElement(
         'div',
         { className: 'KanbanWrapper' },
+        _react2.default.createElement(
+          'button',
+          { onClick: this.print },
+          'Click to print this component! (does not work with ctrl+p).'
+        ),
         _react2.default.createElement(
           _reactVirtualized.AutoSizer,
           null,
@@ -90,19 +125,19 @@ var App = function (_Component) {
             var width = _ref.width,
                 height = _ref.height;
             return _react2.default.createElement(_2.VirtualKanban, {
-              lists: _this2.state.lists,
+              lists: _this3.state.lists,
               width: width,
               height: height,
               listWidth: 400,
               onMoveRow: function onMoveRow(_ref2) {
                 var lists = _ref2.lists;
-                return _this2.setState(function () {
+                return _this3.setState(function () {
                   return { lists: lists };
                 });
               },
               onMoveList: function onMoveList(_ref3) {
                 var lists = _ref3.lists;
-                return _this2.setState(function () {
+                return _this3.setState(function () {
                   return { lists: lists };
                 });
               },
@@ -124,7 +159,8 @@ var App = function (_Component) {
               onDragEndList: function onDragEndList(data) {
                 return void 0;
               },
-              dndDisabled: false
+              dndDisabled: false,
+              isPrinting: _this3.state.isPrinting
             });
           }
         )

--- a/src/Kanban/index.js
+++ b/src/Kanban/index.js
@@ -53,6 +53,7 @@ class Kanban extends React.PureComponent {
     overscanListCount: 2,
     overscanRowCount: 2,
     dndDisabled: false,
+    isPrinting: false,
   }
 
   static childContextTypes = {
@@ -85,6 +86,8 @@ class Kanban extends React.PureComponent {
     this.findItemIndex = this.findItemIndex.bind(this);
     this.drawFrame = this.drawFrame.bind(this);
     this.findItemIndex = this.findItemIndex.bind(this);
+
+    this.overscanIndicesGetter = this.overscanIndicesGetter.bind(this);
 
     this.refsByIndex = {};
   }
@@ -219,6 +222,16 @@ class Kanban extends React.PureComponent {
     return findItemIndex(this.state.lists, itemId);
   }
 
+  /**
+   * Allows us to render the entire virtualized component for printing.
+   */
+  overscanIndicesGetter({ cellCount }) {
+    return ({
+      overscanStartIndex: 0,
+      overscanStopIndex: cellCount - 1,
+    });
+  }
+
   renderList({ columnIndex, rowIndex, key, style, parent }) {
     const list = this.state.lists[columnIndex];
 
@@ -259,7 +272,16 @@ class Kanban extends React.PureComponent {
       listPreviewComponent,
       overscanListCount,
       initialColumnIndex,
+      isPrinting,
     } = this.props;
+    // Conditionally override the default 'overscanIndicesGetter' function in
+    // react-virtual-grid, which normally tells us to render only enough items
+    // to fill the viewport. If we're not printing the component, then we pass
+    // in 'undefined' so react-virtual-grid uses its defaultOverscanIndicesGetter.
+    const overscanIndicesGetter = isPrinting
+      ? this.overscanIndicesGetter
+      : undefined;
+
     return (
       <div>
         <GridWithScrollZone
@@ -280,6 +302,7 @@ class Kanban extends React.PureComponent {
           scrollToColumn={initialColumnIndex}
           verticalStrength={() => {}}
           speed={HORIZONTAL_SCROLL_SPEED}
+          overscanIndicesGetter={overscanIndicesGetter}
         />
         <DragLayer
           lists={lists}

--- a/src/Kanban/propTypes.js
+++ b/src/Kanban/propTypes.js
@@ -20,3 +20,4 @@ export const initialRowIndex = PropTypes.number;
 export const dndDisabled = PropTypes.bool;
 export const listComponentProps = PropTypes.object;
 export const itemComponentProps = PropTypes.object;
+export const isPrinting = PropTypes.bool;

--- a/src/demo/App.css
+++ b/src/demo/App.css
@@ -9,3 +9,11 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+button {
+  height: 50px;
+  width: 250px;
+  border-radius: 20px;
+  font-size: 14px;
+  margin: 5px;
+}

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -12,6 +12,7 @@ class App extends Component {
 
     this.state = {
       lists: props.getLists(),
+      isPrinting: false,
     };
 
     setInterval(() => {
@@ -29,11 +30,32 @@ class App extends Component {
         }
       });
     }, 30000);
+
+    this.print = this.print.bind(this);
+  }
+
+  /**
+   * This is how we tell the React VirtualKanban component that it needs to render
+   * its entire contents before printing.
+   */
+  print() {
+    new Promise((resolve) => {
+      this.setState({ isPrinting: true }, () => console.log('state', this.state));
+      // or use the redux store and fire an action here
+      resolve();
+    })
+      .then(() => window.alert('There is no print specific styling applied to ' +
+      'this, but check dev tools and you\'ll see all lists rendered to the DOM. ' +
+      'Check now, while this alert is still up, before the preview opens, so you believe me'))
+      .then(() => window.print());
   }
 
   render() {
     return (
       <div className='KanbanWrapper'>
+        <button onClick={this.print}>
+          Click to print this component! (does not work with ctrl+p).
+        </button>
         <AutoSizer>
           {({ width, height }) => (
             <VirtualKanban
@@ -50,6 +72,7 @@ class App extends Component {
               onDragBeginList={(data) => console.log(data, 'onDragBeginList')}
               onDragEndList={(data) => console.log(data, 'onDragEndList')}
               dndDisabled={false}
+              isPrinting={this.state.isPrinting}
             />
           )}
         </AutoSizer>


### PR DESCRIPTION
[Jira Ticket](https://aerofs.atlassian.net/browse/ENG-10276)

Related to [this workspace printing PR](https://github.com/redbooth/redbooth-frontend/pull/4899).

We need a way to let the virtualized kanban component that it needs to render the entire list, and not just what's within the viewport. The reason we have to do this is to enable printing in our kanban workspace view; since not all tasks are rendered, we can't print them until they are.

Now, we pass in a prop, isPrinting, which we use to determine if we should pass in our custom overscanIndicesGetter function.

Just using 'overscanListCount' wasn't cutting it, because it turns out that prop only refers to items past what's currently rendered *in the direction the user is scrolling*. That means that if the user scrolled through their workspace, that only some task lists would re-render for printing.