### PR TITLE
Conditionally scroll to row & fix jumping lists

### DIFF
--- a/lib/Kanban/index.js
+++ b/lib/Kanban/index.js
@@ -334,7 +334,7 @@ var Kanban = function (_React$PureComponent) {
         overscanRowCount: this.props.overscanRowCount,
         findItemIndex: this.findItemIndex,
         dndDisabled: this.props.dndDisabled,
-        initialRowIndex: this.props.initialRowIndex,
+        initialRowIndex: columnIndex === this.props.initialColumnIndex ? this.props.initialRowIndex : undefined,
         listComponentProps: this.props.listComponentProps,
         itemComponentProps: this.props.itemComponentProps
       });

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -100,7 +100,7 @@ var SortableList = function (_React$PureComponent) {
       var rowIndex = this.findHighestUpdatedRow(this.props.list.rows, prevProps.list.rows);
       if (rowIndex !== null) {
         this.cache.clearAll();
-        if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex + 1);
+        if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex);
       }
     }
   }, {
@@ -119,7 +119,7 @@ var SortableList = function (_React$PureComponent) {
     key: 'recalculateRowHeights',
     value: function recalculateRowHeights(index) {
       this.cache.clear(index);
-      if (this._list) this._list.wrappedInstance.recomputeRowHeights(index + 1);
+      if (this._list) this._list.wrappedInstance.recomputeRowHeights(index);
     }
   }, {
     key: 'renderRow',

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -107,13 +107,9 @@ var SortableList = function (_React$PureComponent) {
     key: 'findHighestUpdatedRow',
     value: function findHighestUpdatedRow(rows, prevRows) {
       if (!window._) return null;
-      for (var i = 0; i < rows.length; i++) {
-        if (!window._.isEqual(rows[i], prevRows[i])) {
-          return i;
-        }
-      }
-
-      return null;
+      return window._.findIndex(rows, function (row, i) {
+        return !window._.isEqual(row, prevRows[i]);
+      });
     }
   }, {
     key: 'recalculateRowHeights',

--- a/src/Kanban/index.js
+++ b/src/Kanban/index.js
@@ -255,7 +255,7 @@ class Kanban extends React.PureComponent {
         overscanRowCount={this.props.overscanRowCount}
         findItemIndex={this.findItemIndex}
         dndDisabled={this.props.dndDisabled}
-        initialRowIndex={this.props.initialRowIndex}
+        initialRowIndex={columnIndex === this.props.initialColumnIndex ? this.props.initialRowIndex : undefined}
         listComponentProps={this.props.listComponentProps}
         itemComponentProps={this.props.itemComponentProps}
       />

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -48,13 +48,7 @@ class SortableList extends React.PureComponent {
 
   findHighestUpdatedRow(rows, prevRows) {
     if (!window._) return null;
-    for (let i = 0; i < rows.length; i++) {
-      if (!window._.isEqual(rows[i], prevRows[i])) {
-        return i;
-      }
-    }
-
-    return null;
+    return window._.findIndex(rows, (row, i) => !window._.isEqual(row, prevRows[i]));
   }
 
   recalculateRowHeights(index) {

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -42,7 +42,7 @@ class SortableList extends React.PureComponent {
     const rowIndex = this.findHighestUpdatedRow(this.props.list.rows, prevProps.list.rows);
     if (rowIndex !== null) {
       this.cache.clearAll();
-      if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex + 1);
+      if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex);
     }
   }
 
@@ -59,7 +59,7 @@ class SortableList extends React.PureComponent {
 
   recalculateRowHeights(index) {
     this.cache.clear(index);
-    if (this._list) this._list.wrappedInstance.recomputeRowHeights(index + 1);
+    if (this._list) this._list.wrappedInstance.recomputeRowHeights(index);
   }
 
   renderRow({ index, key, style, parent}) {


### PR DESCRIPTION
Previously each SortableList component received a copy of whatever `initialRowIndex` was provided to the Kanban component. This caused all task lists to scroll to the specified index, not just the specific task list that was specified by `initialColumnIndex`.

Also fix a bug where the wrong index was getting called with `recomputeRowHeights`