### PR TITLE
Only update cell cache if list is empty

### DIFF
--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -98,7 +98,7 @@ var SortableList = function (_React$PureComponent) {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps) {
       var rowIndex = this.findHighestUpdatedRow(this.props.list.rows, prevProps.list.rows);
-      if (rowIndex !== null) {
+      if (rowIndex !== null && this.props.list.rows.length) {
         this.cache.clearAll();
         if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex);
       }
@@ -115,7 +115,9 @@ var SortableList = function (_React$PureComponent) {
     key: 'recalculateRowHeights',
     value: function recalculateRowHeights(index) {
       this.cache.clear(index);
-      if (this._list) this._list.wrappedInstance.recomputeRowHeights(index);
+      if (this._list && this.props.list.rows.length) {
+        this._list.wrappedInstance.recomputeRowHeights(index);
+      }
     }
   }, {
     key: 'renderRow',

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -40,9 +40,9 @@ class SortableList extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     const rowIndex = this.findHighestUpdatedRow(this.props.list.rows, prevProps.list.rows);
-    if (rowIndex !== null) {
+    if (rowIndex !== null && this.props.list.rows.length) {
       this.cache.clearAll();
-      if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex + 1);
+      if (this._list) this._list.wrappedInstance.recomputeRowHeights(rowIndex);
     }
   }
 
@@ -53,7 +53,9 @@ class SortableList extends React.PureComponent {
 
   recalculateRowHeights(index) {
     this.cache.clear(index);
-    if (this._list) this._list.wrappedInstance.recomputeRowHeights(index + 1);
+    if (this._list && this.props.list.rows.length) {
+      this._list.wrappedInstance.recomputeRowHeights(index);
+    }
   }
 
   renderRow({ index, key, style, parent}) {


### PR DESCRIPTION
I noticed a bug where empty lists would occasionally be asked to recalculate their row heights which react-virtualized doesn't know how to handle. To avoid this just make sure the list is empty before calling `recomputeRowHeights`