### PR TITLE
ENG-10834 Ensure row has changed before recalculating row height

### DIFF
--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -107,9 +107,11 @@ var SortableList = function (_React$PureComponent) {
     key: 'findHighestUpdatedRow',
     value: function findHighestUpdatedRow(rows, prevRows) {
       if (!window._) return null;
-      return window._.findIndex(rows, function (row, i) {
-        return !window._.isEqual(row, prevRows[i]);
-      });
+      for (var i = 0; i < rows.length; i++) {
+        if (!window._.isEqual(rows[i], prevRows[i])) return i;
+      }
+
+      return null;
     }
   }, {
     key: 'recalculateRowHeights',

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -48,7 +48,11 @@ class SortableList extends React.PureComponent {
 
   findHighestUpdatedRow(rows, prevRows) {
     if (!window._) return null;
-    return window._.findIndex(rows, (row, i) => !window._.isEqual(row, prevRows[i]));
+    for (let i = 0; i < rows.length; i++) {
+      if (!window._.isEqual(rows[i], prevRows[i])) return i;
+    }
+
+    return null;
   }
 
   recalculateRowHeights(index) {


### PR DESCRIPTION
[Jira ticket](https://aerofs.atlassian.net/browse/ENG-10834)
Dependent on frontend PR: https://github.com/redbooth/redbooth-frontend/pull/5042

`findHighestUpdatedRow` was calling `_.findIndex`, which returns `-1` when no match is found. The check made in `componentDidUpdate` was only checking if `rowIndex` was null, not -1. In order to simplify the check made before calling `recomputeRowHeights`, ensure `findHighestUpdated` row only returns either a valid index or null.

This fixes the issue of task lists jumping when they are scrolled to the bottom and the workspace is scrolled horizontally.

![scroll](https://media.giphy.com/media/3oxHQK55lJgBfctUVq/giphy.gif)